### PR TITLE
Consider requests and comupute requests

### DIFF
--- a/src/fastly/calculate.test.ts
+++ b/src/fastly/calculate.test.ts
@@ -34,7 +34,7 @@ describe("calculate() test", () => {
     const result = calculate(c, units);
     expect(result).toMatchObject({
       bandwidth: 2,
-      requests: 2,
+      requests: 200,
       computeRequests: 2,
       computeDurations: 25,
     });
@@ -62,7 +62,7 @@ describe("calculateBillingUnits() test", () => {
     const { bandwidth, requests, computeRequests, computeDurations } =
       calculateBillingUnits(s);
     expect(bandwidth).toBe(20);
-    expect(requests).toBe(20);
+    expect(requests).toBe(2000);
     expect(computeRequests).toBe(20);
     expect(computeDurations).toBe(250);
   });

--- a/src/fastly/calculate.ts
+++ b/src/fastly/calculate.ts
@@ -65,9 +65,15 @@ export function calculateStatistics(
 // Calculate statistics to billing unit
 export function calculateBillingUnits(stat: StatAPISchema): BillingUnits {
   // Avoid zero division
+  // Note that on Compute request, the requests field always set to 0.
+  // But actually Fastly bills for the request (means Edge POP request),
+  // we need to treat requests as the same as compute_requests.
+  const requests =
+    stat.compute_requests > 0 ? stat.compute_requests : stat.requests;
+
   return {
     bandwidth: stat.bandwidth > 0 ? stat.bandwidth / bandwidthUnit : 0,
-    requests: stat.requests > 0 ? stat.requests / requestUnit : 0,
+    requests: requests > 0 ? requests / requestUnit : 0,
     computeRequests:
       stat.compute_requests > 0
         ? stat.compute_requests / computeRequestUnit


### PR DESCRIPTION
Found a wrong calculation for compute requests.
If the service is "compute", we need to calculate Edge POP requests as `requests`. However the `requests` field would be zero so then we use `compute_requests` field value as the Edge POP requests.